### PR TITLE
Enforce Changing steamcmd branch back to public on default frameworks

### DIFF
--- a/games/carbon/helpers/steamcmd.sh
+++ b/games/carbon/helpers/steamcmd.sh
@@ -38,7 +38,7 @@ function SteamCMD_Validate() {
     else
         Delete_SteamApps_Directory
         Info "Downloading Default Files - Validation On!"
-        ./steamcmd/steamcmd.sh +force_install_dir /home/container +login anonymous +app_update 258550 validate +quit
+        ./steamcmd/steamcmd.sh +force_install_dir /home/container +login anonymous +app_update 258550 -beta public validate +quit
     fi
 }
 
@@ -57,6 +57,6 @@ function SteamCMD_No_Validation() {
         ./steamcmd/steamcmd.sh +force_install_dir /home/container +login anonymous +app_update 258550 -beta staging +quit
     else
         Info "Downloading Default Files - Validation Off!"
-        ./steamcmd/steamcmd.sh +force_install_dir /home/container +login anonymous +app_update 258550 +quit
+        ./steamcmd/steamcmd.sh +force_install_dir /home/container +login anonymous +app_update 258550 -beta public +quit
     fi
 }


### PR DESCRIPTION
as per https://github.com/GameServerManagers/LinuxGSM/issues/1913 when a -beta flag is provided steam will store the value of this flag in `steamapps/appmanifest_258550.acf` and re-use it when no beta flag is provided, so switching to an aux or staging branch and then changing back would result in steam continuing to use the last branch